### PR TITLE
Add French marketplace metadata

### DIFF
--- a/locale/fr-fr/pyradios.voc
+++ b/locale/fr-fr/pyradios.voc
@@ -1,1 +1,3 @@
 (avec|dans|sur|) (pyradio|pyradios)
+pyradio
+pyradios

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -2,7 +2,7 @@
   "skill_id": "ovos-skill-pyradios.openvoiceos",
   "source": "https://github.com/OpenVoiceOS/ovos-skill-pyradios",
   "name": "Pyradios",
-  "description": "Un client pour l'API Radio Browser.",
+  "description": "Permet d'écouter des radios du monde entier via Radio Browser.",
   "examples": [
     "Joue TSF Jazz Radio",
     "Joue TSF Jazz sur Pyradios"

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,16 @@
+{
+  "skill_id": "ovos-skill-pyradios.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-pyradios",
+  "name": "Pyradios",
+  "description": "Un client pour l'API Radio Browser.",
+  "examples": [
+    "Joue TSF Jazz Radio",
+    "Joue TSF Jazz sur Pyradios"
+  ],
+  "tags": [
+    "média",
+    "musique",
+    "divertissement",
+    "OCP"
+  ]
+}


### PR DESCRIPTION
## Summary
- add localized French skill metadata for Pyradios
- expand the French Pyradios vocabulary with direct tool name variants

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON