### PR TITLE
chore(ovos-skill-pyradios): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ovos-utils >= 0.1.0
 ovos-bus-client>=0.0.9
-ovos-workshop>=8.0.0,<8.1.0
+ovos-workshop>=8.0.0,<9.0.0
 pyradios
 dead-simple-cache>=1.2.2
 rapidfuzz


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0