### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ovos-utils >= 0.1.0
 ovos-bus-client>=0.0.9
-ovos-workshop>=8.0.0,<9.0.0
+ovos-workshop>=8.0.0,<10.0.0
 pyradios
 dead-simple-cache>=1.2.2
 rapidfuzz


### PR DESCRIPTION
ovos-core 2.5.0a2 requires `ovos-workshop>=9.0.2a1`; this repo's `<9.0.0` cap is one of 24 blocking the auto-generated constraints-alpha from resolving latest workshop (caught by raspOVOS's new Tier 2 `pip check` gate, which found shipped images with a broken dep graph). Cap bumped to `<10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)